### PR TITLE
reverts vscode type upgrade to restore version compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "^4.0.0",
@@ -23,7 +23,7 @@
         "@types/mocha": "^10.0.3",
         "@types/node": "^20.8.9",
         "@types/ps-tree": "^1.1.4",
-        "@types/vscode": "^1.83.1",
+        "@types/vscode": "^1.63.1",
         "@vscode/test-electron": "^2.3.6",
         "cross-env": "^7.0.3",
         "glob": "^10.3.10",
@@ -39,7 +39,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.83.1"
+        "vscode": "^1.63.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.1.1",
   "publisher": "getgauge",
   "engines": {
-    "vscode": "^1.83.1"
+    "vscode": "^1.63.1"
   },
   "categories": [
     "Programming Languages"
@@ -462,7 +462,7 @@
     "@types/mocha": "^10.0.3",
     "@types/node": "^20.8.9",
     "@types/ps-tree": "^1.1.4",
-    "@types/vscode": "^1.83.1",
+    "@types/vscode": "^1.63.1",
     "@vscode/test-electron": "^2.3.6",
     "cross-env": "^7.0.3",
     "glob": "^10.3.10",


### PR DESCRIPTION
the automatic upgrade bumped the `@types/vscode` and `"engines": {"vscode": "^1.63.1"}` which removed all backwards compatibility
this change can be savely reverted as this extension doesn't use any newly introduced vscode interfaces